### PR TITLE
Excluding Git history

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     - name: Deploy FTP
       uses: sebastianpopp/ftp-action@master
       with:
-        host: "ftp.example.com"
+        host: ${{ secrets.FTP_SERVER }}
         user: ${{ secrets.FTP_USERNAME }}
         password: ${{ secrets.FTP_PASSWORD }}
         localDir: "dist"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R -c -L -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror --reverse --continue --dereference -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-set -eu
-
-echo "Starting FTP Deploy"
-
-echo "Using $INPUT_USER to connect to $INPUT_HOST"
-
-echo "Mirroring from $INPUT_LOCALDIR to $INPUT_REMOTEDIR"
+set -e
 
 lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror --reverse --continue --dereference -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
-
-echo "FTP Deploy Complete"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R -c -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R -c -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror -R -c -L -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
-set -e
+set -eu
+
+echo "Starting FTP Deploy"
+
+echo "Using $INPUT_USER to connect to $INPUT_HOST"
+
+echo "Mirroring from $INPUT_LOCALDIR to $INPUT_REMOTEDIR"
 
 lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ssl:verify-certificate false; mirror --reverse --continue --dereference -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+
+echo "FTP Deploy Complete"


### PR DESCRIPTION
Comparing all Git files on every action takes up time and I’m assuming people don’t need the Git history to be available on their FTP server.

Also turned the server URL into a secret, made the commands verbose, and added progress feedback.