### PR TITLE
Fixes "mirror: Access failed: 534 Protection level negotiation failed"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ftp:ssl-force $INPUT_FORCESSL; set ssl:verify-certificate false; mirror --reverse --continue --dereference -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ftp:ssl-force $INPUT_FORCESSL; set ssl:verify-certificate false; set ftp:ssl-protect-data true; mirror --reverse --continue --dereference -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"


### PR DESCRIPTION
Trying it out Shared Hosting services with FTP service that uses FTP over TLS/SSL, encountered error: **mirror: Access failed: 534 Protection level negotiation failed**, additional settings for lftp to introduce a fix.