### PR TITLE
remove localDir prefix in remoteDir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ftp:ssl-force $INPUT_FORCESSL; set ssl:verify-certificate false; mirror --reverse --continue --dereference -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
+lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ftp:ssl-force $INPUT_FORCESSL; set ssl:verify-certificate false; lcd $INPUT_LOCALDIR; mirror --reverse --continue --dereference -x ^\.git/$ ./ $INPUT_REMOTEDIR; quit"


### PR DESCRIPTION
This PR removes the localDir as a prefix in the remote directory.

Previously a file called "test.txt" would be uploaded to "remoteDir/localDir/test.txt". This PR changes to path on the  server to "remoteDir/test.txt".

If this is a intended feature don't hesitate to close this PR.